### PR TITLE
add supertest dependency 

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "mocha": "^2.4.5",
     "run-sequence": "^1.1.5",
     "sinon": "^1.17.3",
+    "supertest": "^1.2.0",
     "supertest-as-promised": "^3.1.0"
   },
   "author": "Daniel Figueiredo Caetano",


### PR DESCRIPTION
was causing `api-tests` task to crash
